### PR TITLE
Registra los directorios de skel en el set skel_files

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -126,7 +126,7 @@ def procesar_entrega(msg):
 
     for fname in filenames:
       full_path = os.path.join(path, fname)
-      arch_path = os.path.join(relpath, fname)
+      arch_path = os.path.relpath(full_path, skel_dir)
       skel_files.add(arch_path)
       tar.add(full_path, arch_path)
 


### PR DESCRIPTION
Esto evita un bug que se da cuando el alumno envía un zip que contiene un archivo con el mismo nombre de un subdirectorio del skel de la entrega.