### PR TITLE
Creación de un PDF de entrega según el zip enviado.

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -344,9 +344,10 @@ def zip_datetime(info):
 
 def make_pdf(zip_obj, nombre, padron, corrector, entrega, id_entrega):
   """Arma un PDF con los archivos de una entrega y los datos
-  del alumno. El archivo se llama siempre igual: entrega.pdf
-  en el directorio actual de trabajo, y se debe borrar luego.
-  A cargo del usuario.
+  del alumno. El archivo se denomina según id_entrega, que
+  puede ser, por ejemplo, el hash del commit a GH.
+  Devuelve el nombre del archivo generado. El borrado queda a 
+  cargo del usuario.
   """
   archivo_salida = id_entrega + ".pdf"
   markdown = """
@@ -432,8 +433,6 @@ def send_reply(orig_msg, reply_text, pdf_entrega):
   server.docmd("AUTH", "XOAUTH2 " + xoauth2_b64)
   server.send_message(reply)
   server.close()
-
-  del_pdf(entrega_pdf)
 
 
 def get_oauth_credentials():

--- a/corrector.py
+++ b/corrector.py
@@ -355,6 +355,12 @@ def make_pdf(zip_obj, nombre, padron, corrector, entrega, id_entrega):
 """.format(entrega, corrector, nombre, padron)
 
   for path, zip_info in zip_walk(zip_obj):
+    archivo = zip_info.filename
+    extension = archivo[-2:]
+
+    if extension!=".c" and extension!=".h":
+      continue
+
     with zip_obj.open(archivo) as f:
         texto = f.read()
     nombre_archivo_solo = archivo.split("/")[-1]

--- a/corrector.py
+++ b/corrector.py
@@ -370,7 +370,8 @@ def make_pdf(zip_obj, nombre, padron, corrector, entrega, id_entrega):
       continue
 
     with zip_obj.open(archivo) as f:
-        texto = f.read()
+      texto = f.read()
+
     nombre_archivo_solo = archivo.split("/")[-1]
     texto_embebido = """
 ### Archivo: {0}   
@@ -378,13 +379,14 @@ def make_pdf(zip_obj, nombre, padron, corrector, entrega, id_entrega):
 {1}
 ```   
 """.format(nombre_archivo_solo, texto)
-    print(texto_embebido)
-    pypandoc.convert_text(
-      texto_embebido,
-      "pdf",
-      format = "md",
-      outputfile = archivo_salida
-    )
+    markdown += texto_embebido
+
+  pypandoc.convert_text(
+    markdown,
+    "pdf",
+    format = "md",
+    outputfile = archivo_salida
+  )
   return archivo_salida
 
 def del_pdf(archivo_entrega):

--- a/corrector.py
+++ b/corrector.py
@@ -161,7 +161,7 @@ def procesar_entrega(msg):
       padron = padron,
       corrector = email_ayudante,
       entrega = tp_id,
-      id_entrega = abs(hash(moss.url())) #id unico (temporario) de la entrega
+      id_entrega = moss.get_hash() #id unico (temporario) de la entrega
     )
 
     send_reply(
@@ -315,6 +315,13 @@ class Moss:
     return subprocess.check_output(
         f'echo "{GITHUB_URL}/tree/$({short_rev})/$({relative_dir})"',
         shell=True, encoding="utf-8", cwd=self._dest)
+
+  def get_hash(self):
+    short_rev = "git show -s --pretty=tformat:%h"
+    return subprocess.check_output(
+      short_rev,
+      shell=True, encoding="utf-8", cwd=self._dest
+    )
 
   def save_data(self, filename, contents):
     """Guarda un archivo si es código fuente.


### PR DESCRIPTION
La idea del PR es que se genere un PDF con ayuda de Markdown y PyPandoc para facilitar la entrega a los alumnos. El PDF tiene todos los source relevantes y da la información de ayudante, alumno, padrón y tipo de entrega.

* Queda testear
* Probablemente haya que filtrar los archivos
 + tal vez sería util tener un mapa tipo_entrega => archivos
 + como mínimo indispensable, hay que sacar los .o, makefile, etc.
* Nota: hay que instalar pypandoc para que funcione
* Quedaría agregar filtros a los archivos
* Puntualmente, la parte que me genera más dudas es la del zip traverse en la generación del .md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/corrector/12)
<!-- Reviewable:end -->
