### PR TITLE
Preservar To, Cc y Reply-To intactos del mensaje original.

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -349,8 +349,10 @@ def send_reply(orig_msg, reply_text):
   reply.set_payload(reply_text, "utf-8")
 
   reply["From"] = GMAIL_ACCOUNT
-  reply["To"] = orig_msg.get("Cc", "")
+  reply["To"] = orig_msg["To"]
+  reply["Cc"] = orig_msg.get("Cc", "")
   reply["Subject"] = "Re: " + orig_msg["Subject"]
+  reply["Reply-To"] = orig_msg.get("Reply-To", "")
   reply["In-Reply-To"] = orig_msg["Message-ID"]
 
   creds = get_oauth_credentials()


### PR DESCRIPTION
De esta manera se propaga lo que se haya configurado desde el sistema de
entregas. Los mensajes que nos llegan deberían ser a través de Bcc.