### PR TITLE
Usar path.write_text() y no write_bytes(), output es cadena.

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -323,7 +323,7 @@ class Moss:
 
   def save_output(self, output):
     filepath = self._dest / "README.md"
-    filepath.write_bytes(f"```\n{output}```")
+    filepath.write_text(f"```\n{output}```")
     return self._git(["add", filepath]) == 0
 
   def commit_emoji(self, output):


### PR DESCRIPTION
Fixes: 467059b "Simplificar save_output() usando path.write_bytes()
y format strings."