### PR TITLE
worker.py: añadir un segundo timeout, para el propio worker.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -26,6 +26,8 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import traceback
+import sys
 
 from java import CorregirJava
 
@@ -100,15 +102,17 @@ def ejecutar(corrector, timeout):
     with tarfile.open(fileobj=sys.stdin.buffer, mode="r|") as tar:
       tar.extractall(tmpdir)
 
-    signal.alarm(int(timeout * 1.5))
+    signal.alarm(timeout + 5)
     try:
       corrector(tmpdir).run(timeout)
     except Timeout:
       # Cada corrector debería comprobar el tiempo, pero este es un error
       # genérico de última instancia.
-      raise ErrorAlumno("El proceso tardó más de {} segundos".format(timeout))
+      raise ErrorAlumno(f"El proceso tardó más de {timeout + 5} segundos")
     finally:
-      signal.alarm(0)
+      # Añadir un segundo timeout para asegurar que ningún código restante
+      # de ejecutar() —por ejemplo, tmpdir.cleanup()— pueda colgar al worker.
+      signal.alarm(timeout // 2)
 
 
 def main():
@@ -125,6 +129,11 @@ def main():
     ejecutar(CORRECTORES[args.corrector], args.timeout)
   except ErrorAlumno as ex:
     print("ERROR: {}.".format(ex))
+  except Timeout as ex:
+    print("\n" "Aviso: se realizó la corrección, pero el "
+          "sistema demoró en retornar la respuesta:\n")
+    traceback.print_tb(ex.__traceback__, file=sys.stdout)
+
 
 ##
 


### PR DESCRIPTION
El proceso worker jamás se debería quedar colgado. Para ello existía
un timeout global con 50% extra de changüí para que esto no sucediese.

Sin embargo, una vez ejecutado el código de los alumnos, pero antes de
realizar las tareas de cleanup, se cancelaba este timeout global.

En este commit se reintroduce, además de:

  - emitir un mensaje si se alcanza este timeout global.

  - no permitir que el proceso de corrección consuma más del timeout
    original (antes podía consumir parte, o todo, del 50% extra).

Closes: #28.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/corrector/29)
<!-- Reviewable:end -->
