### PR TITLE
Preservar en Git la estructura de directorios de la entrega.

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -297,14 +297,15 @@ class Moss:
         f'echo "{GITHUB_URL}/tree/$({short_rev})/$({relative_dir})"',
         shell=True, encoding="utf-8", cwd=self._dest)
 
-  def save_data(self, filename, contents):
+  def save_data(self, relpath, contents):
     """Guarda un archivo si es código fuente.
 
     Devuelve True si se guardó, False si se decidió no guardarlo.
     """
-    path = self._dest / filename.name
+    path = self._dest / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(contents)
-    return self._git(["add", path.name]) == 0
+    return self._git(["add", relpath]) == 0
 
   def flush(self):
     """Termina de guardar los archivos en el repositorio.


### PR DESCRIPTION
Esto solo produce cambios si el ZIP tiene múltiples subdirectorios, por
ejemplo, para definir paquetes de Java. Si el ZIP tiene un único directorio
en el nivel raíz, ya se le estaba ignorando por omisión en zip_walk().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/corrector/35)
<!-- Reviewable:end -->
