### PR TITLE
Envío de entregas a repositorios individuales de Github

### DIFF
--- a/alu_repos.py
+++ b/alu_repos.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """Clase AluRepo para manejar los repositorios individuales y grupales.
 """
 

--- a/alu_repos.py
+++ b/alu_repos.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+
+"""Clase AluRepo para manejar los repositorios individuales y grupales.
+"""
+
+import base64
+import csv
+import io
+import os
+import random
+import pathlib
+import tempfile
+
+from datetime import datetime, timezone
+from typing import List, Type, TypeVar
+
+import git
+import github
+
+from git.objects.fun import traverse_tree_recursive
+from git.util import stream_copy
+from github import InputGitTreeElement
+from github.Repository import Repository as GithubRepo
+
+T = TypeVar("T", bound="AluRepo")
+
+ROOT_DIR = pathlib.Path(os.environ["CORRECTOR_ROOT"])
+PLANILLA_TSV = ROOT_DIR / "conf" / "repos.tsv"
+
+GITHUB_TOKEN = os.environ["CORRECTOR_GH_TOKEN"]
+DEFAULT_GHUSER = os.environ["CORRECTOR_GH_USER"]
+
+# XXX Temporario 2020/1. Maneja a qué personas se les incluye
+# el enlace al repo en el mail que envía el corrector.
+REVIEWEE_INDIV = {
+    "54321",
+}
+
+# Poner aquí los padrones de integrantes de grupos, pero *solo*
+# si el grupo tiene dos miembros. Si no, ponerlos en REVIEW_INDIV.
+REVIEWEE_GRUPAL = {
+    "543421",
+}
+
+
+class AluRepo:
+    """Clase para manejar los repositorios individuales y grupales.
+    """
+
+    # TODO: separar esta clase en dos, una para obtener el nombre de los repos
+    # (primeros tres métodos), y otra para meramente (métodos sync y ensure_exists).
+
+    DEFAULT_COLUMN = "Repo"
+
+    def __init__(
+        self, repo_full: str, legajos: List[str], github_users: List[str] = None,
+    ):
+        """Constructor de la clase AluRepo.
+
+        Normalmente no se usa directamente, sino que se usa uno de:
+
+          • AluRepo.from_legajo
+          • AluRepo.from_grupo
+          • AluRepo.from_legajos
+        """
+        self.gh_repo = None
+        self.legajos = set(legajos)
+        self.repo_full = repo_full
+        self.github_users = github_users or [DEFAULT_GHUSER]
+
+    @classmethod
+    def from_legajo(
+        cls: Type[T], legajo: str, /, tp_id: str = None, *, force_column: str = None
+    ) -> T:
+        """Devuelve el AluRepo correspondiente a un legajo y entrega.
+
+        Si se especifica una entrega con `tp_id`, se busca en la configuración
+        qué columna de la planilla corresponde. Si no se indica entrega, el
+        repositorio se busca en la columna DEFAULT_COLUMN, o `force_column` si
+        se especifica.
+
+        ==> Este método es el apropiado para entregas individuales, y funciona
+            también para grupos, componiendo los legajos en una sola cadena,
+            separados por caracter subrayado ("12345_123456", etc.).
+
+        Raises:
+          KeyError si no se encuentra el legajo
+          ValueError si no hay repositorio configurado
+        """
+        if tp_id is not None and force_column is not None:
+            raise ValueError("tp_id y force_column son incompatibles")
+
+        column = cls.DEFAULT_COLUMN if force_column is None else force_column
+
+        # TODO: mover esto a repos.yml
+        if tp_id in {"abb", "hash", "heap", "tp2", "tp3"} or "_" in legajo:
+            column = "Repo2"
+
+        return cls.from_legajos(legajo.split("_"), column=column)
+
+    @classmethod
+    def from_grupo(cls: Type[T], group_id: List[str] = None) -> T:
+        """Devuelve el objeto AluRepo correspondiente a un grupo.
+
+        ==> Este es el mejor método para entregas grupales, si se sabe el nombre
+            del grupo.
+
+        Raises:
+          KeyError si no se encuentra el legajo
+          ValueError si no hay repositorio configurado, o no es único
+        """
+        legajos = []
+
+        with open(PLANILLA_TSV, newline="") as fileobj:
+            for row in csv.DictReader(fileobj, dialect="excel-tab"):
+                if row["Grupo"] == group_id:
+                    legajos.append(row["Legajo"])
+
+        if not legajos:
+            raise KeyError(f"no se encontró grupo {group_id} en la planilla")
+
+        return cls.from_legajos(legajos, column="Repo2")
+
+    @classmethod
+    def from_legajos(cls: Type[T], legajos: List[str], /, *, column: str) -> T:
+        """Función genérica para obtener un repositorio.
+
+        Si no se especifica force_column, se usa DEFAULT_COLUMN. Si legajos
+        tiene más de un elemento, pero los repositorios no coinciden, se lanza
+        ValueError.
+
+        Esta función no se debería usar directamente, y debería preferirsse una
+        de las dos anteriores.
+        """
+        rows = []
+
+        with open(PLANILLA_TSV, newline="") as fileobj:
+            for row in csv.DictReader(fileobj, dialect="excel-tab"):
+                if row["Legajo"] in legajos:
+                    rows.append(row)
+
+        if not rows:
+            s = "s" if legajos[1:] else ""
+            legajos_fmt = ", ".join(legajos)
+            raise KeyError(f"no se encontró legajo{s} {legajos_fmt} en la planilla")
+
+        repo_names = set()
+        github_names = []
+
+        for row in rows:
+            if name := row[column]:
+                repo_names.add(name)
+            if ghuser := row["Github"]:
+                github_names.append(ghuser)
+
+        if not repo_names:
+            raise ValueError(f"columna {column} vacía para {legajos}")
+        elif len(repo_names) > 1:
+            raise ValueError(f"múltiples repos posibles: {repo_names}")
+        else:
+            repo_full = repo_names.pop()
+
+        return cls(repo_full, legajos, github_names)
+
+    @property
+    def url(self):
+        return f"https://github.com/{self.repo_full}"
+
+    def ensure_exists(self, *, skel_repo: str = None):
+        """Crea el repositorio en Github, si no existe aún.
+
+        Si el repositorio ya existe, no se hace nada. Si no existe, se lo
+        crea y se le inicializa con los contenidos de `skel_repo`.
+
+        Raises:
+          github.GithubException si no se pudo crear el repositorio.
+        """
+        gh = github.Github(GITHUB_TOKEN)
+        try:
+            self.gh_repo = gh.get_repo(self.repo_full)
+        except github.UnknownObjectException:
+            pass
+        else:
+            return
+
+        owner, name = self.repo_full.split("/", 1)
+        organization = gh.get_organization(owner)
+
+        # TODO: get all settings from repos.yml
+        organization.create_repo(
+            name,
+            private=True,
+            has_wiki=False,
+            has_projects=False,
+            has_downloads=False,
+            allow_squash_merge=False,
+            allow_rebase_merge=False,
+        )
+
+        # TODO: poner skel_repo en la configuración.
+        if skel_repo is not None:
+            skel_repo = f"git@github.com:{skel_repo}"
+            repo_full = f"git@github.com:{self.repo_full}"
+            with tempfile.TemporaryDirectory() as tmpdir:
+                git.Repo.clone_from(skel_repo, tmpdir)
+                git.cmd.Git(working_dir=tmpdir).push(
+                    [repo_full, "refs/remotes/origin/*:refs/heads/*"]
+                )
+
+        # TODO: set up team access
+        # TODO: configure branch protections
+
+    def has_reviewer(self):
+        # TODO: usar la columna Reviewer de la planilla?
+        reviewees = REVIEWEE_GRUPAL if len(self.legajos) > 1 else REVIEWEE_INDIV
+        return not self.legajos.isdisjoint(reviewees)
+
+    def sync(self, entrega_dir: pathlib.Path, rama: str, *, target_subdir: str = None):
+        """Importa una entrega a los repositorios de alumnes.
+
+        Args:
+          entrega_dir: ruta en repo externo con los archivos actualizados.
+          rama: rama en la que actualizar la entrega.
+          target_subdir: directorio que se debe actuaizar dentro el repositorio.
+              Si no se especifica, se usa el nombre de la rama (usar la cadena
+              vacía para actualizar el toplevel).
+
+        Raises:
+          github.UnknownObjectException si el repositorio no existe.
+          github.GithubException si se recibió algún otro error de la API.
+        """
+        if target_subdir is None:
+            target_subdir = rama
+
+        gh = github.Github(GITHUB_TOKEN)
+        repo = self.gh_repo or gh.get_repo(self.repo_full)
+        gitref = repo.get_git_ref(f"heads/{rama}")
+        ghuser = random.choice(self.github_users)  # ¯\_(ツ)_/¯ Only entregas knows.
+
+        # Estado actual del repo.
+        cur_sha = gitref.object.sha
+        cur_tree = repo.get_git_tree(cur_sha)
+        cur_commit = repo.get_git_commit(cur_sha)
+
+        # Examinar el repo de entregas para obtener los commits a aplicar.
+        entrega_repo = git.Repo(entrega_dir, search_parent_directories=True)
+        entrega_relpath = entrega_dir.relative_to(entrega_repo.working_dir).as_posix()
+        pending_commits = []
+        cur_commit_date = cur_commit.author.date
+
+        # La fecha de la API siempre viene en UTC, pero PyGithub no le asigna
+        # timezone, y se interpretaría en zona horaria local por omisión. Ver
+        # https://github.com/PyGithub/PyGithub/pull/704.
+        cur_commit_date = cur_commit_date.replace(tzinfo=timezone.utc)
+
+        for commit in entrega_repo.iter_commits(paths=[entrega_relpath]):
+            if commit.authored_date > cur_commit_date.timestamp():
+                pending_commits.append(commit)
+
+        for commit in reversed(pending_commits):
+            # TODO: lidiar con archivos borrados.
+            entrega_tree = commit.tree.join(entrega_relpath)
+            tree_contents = tree_to_github(entrega_tree, target_subdir, repo)
+            author_date = datetime.fromtimestamp(commit.authored_date).astimezone()
+            author_info = github.InputGitAuthor(
+                ghuser, f"{ghuser}@users.noreply.github.com", author_date.isoformat()
+            )
+            cur_tree = repo.create_git_tree(tree_contents, cur_tree)
+            cur_commit = repo.create_git_commit(
+                commit.message, cur_tree, [cur_commit], author_info
+            )
+
+        gitref.edit(cur_commit.sha)
+
+
+def tree_to_github(
+    tree: git.Tree, target_subdir: str, gh_repo: GithubRepo
+) -> List[InputGitTreeElement]:
+    """Extrae los contenidos de un commit de Git en formato Tree de Github.
+    """
+    odb = tree.repo.odb
+    target_subdir = target_subdir.rstrip("/") + "/"
+    entries = traverse_tree_recursive(odb, tree.binsha, target_subdir)
+    contents = []
+
+    for sha, mode, path in entries:
+        # TODO: get exclusion list from repos.yml
+        if path.endswith("README.md"):
+            continue
+        fileobj = io.BytesIO()
+        stream_copy(odb.stream(sha), fileobj)
+        fileobj.seek(0)
+        try:
+            text = fileobj.read().decode("utf-8")
+            input_elem = InputGitTreeElement(path, f"{mode:o}", "blob", text)
+        except UnicodeDecodeError:
+            # POST /trees solo permite texto, hay que crear un blob para binario.
+            fileobj.seek(0)
+            data = base64.b64encode(fileobj.read())
+            blob = gh_repo.create_git_blob(data.decode("ascii"), "base64")
+            input_elem = InputGitTreeElement(path, f"{mode:o}", "blob", sha=blob.sha)
+        finally:
+            contents.append(input_elem)
+
+    return contents
+
+
+# Local Variables:
+# eval: (blacken-mode 1)
+# End:

--- a/conf/corrector.env
+++ b/conf/corrector.env
@@ -1,6 +1,7 @@
 # Rutas relativas.
 CORRECTOR_TPS="data/tps"
 CORRECTOR_SKEL="data/skel"
+CORRECTOR_REPOS="data/repos"
 CORRECTOR_MOSS="bin/moss"
 CORRECTOR_MAIN="bin/corrector"
 CORRECTOR_WORKER="bin/worker"

--- a/conf/corrector.env
+++ b/conf/corrector.env
@@ -1,7 +1,6 @@
 # Rutas relativas.
 CORRECTOR_TPS="data/tps"
 CORRECTOR_SKEL="data/skel"
-CORRECTOR_REPOS="data/repos"
 CORRECTOR_MOSS="bin/moss"
 CORRECTOR_MAIN="bin/corrector"
 CORRECTOR_WORKER="bin/worker"
@@ -13,6 +12,7 @@ CORRECTOR_RUN_GROUP="fiuba7541"
 # Usuario y repo de GitHub.
 CORRECTOR_GH_REPO="algoritmos-rw/algo2_entregas"
 CORRECTOR_GH_USER="wachenbot"
+CORRECTOR_GH_TOKEN=""
 
 # Autenticación de GMail (OAuth).
 CORRECTOR_ACCOUNT="tps.7541rw@gmail.com"

--- a/corrector.py
+++ b/corrector.py
@@ -47,11 +47,17 @@ import zipfile
 import httplib2
 import oauth2client.client
 
+import pull_requests as pullreq
+
 ROOT_DIR = pathlib.Path(os.environ["CORRECTOR_ROOT"])
 SKEL_DIR = ROOT_DIR / os.environ["CORRECTOR_SKEL"]
 DATA_DIR = ROOT_DIR / os.environ["CORRECTOR_TPS"]
 WORKER_BIN = ROOT_DIR / os.environ["CORRECTOR_WORKER"]
 GITHUB_URL = "https://github.com/" + os.environ["CORRECTOR_GH_REPO"]
+
+# Para el sistema de pull requests.
+REPO_TSV = ROOT_DIR / "conf" / "fiubatp.tsv"
+REPO_DIR = ROOT_DIR / os.environ["CORRECTOR_REPOS"]
 
 MAX_ZIP_SIZE = 1024 * 1024  # 1 MiB
 PADRON_REGEX = re.compile(r"\b(SP\d+|CBC\d+|\d{5,})\b")
@@ -159,6 +165,11 @@ def procesar_entrega(msg):
   stdout, _ = worker.communicate()
   output = stdout.decode("utf-8")
   retcode = worker.wait()
+
+  try:
+    pullreq.update_repo(tp_id, REPO_DIR / padron, moss.location(), REPO_TSV)
+  except Exception as ex:
+    print(f"Error al exportar a repositorio individual: {ex}", file=sys.stderr)
 
   if retcode == 0:
     send_reply(msg, output + "\n\n" +
@@ -299,6 +310,11 @@ class Moss:
     self._dest.mkdir(parents=True)
     self._date = subj_date  # XXX(dato): verify RFC822
     self._commit_message = f"New {tp_id} upload from {padron}"
+
+  def location(self):
+    """Directorio donde se guardaron los archivos.
+    """
+    return self._dest
 
   def url(self):
     short_rev = "git show -s --pretty=tformat:%h"

--- a/corrector.py
+++ b/corrector.py
@@ -172,7 +172,7 @@ def procesar_entrega(msg):
   if TODO_OK_REGEX.search(output):
     try:
       # Sincronizar la entrega con los repositorios individuales.
-      alu_repo = AluRepo()
+      alu_repo = AluRepo.from_legajos(padron.split("_"), tp_id)
       alu_repo.ensure_exists(skel_repo="algorw-alu/algo2_tps")
       alu_repo.sync(moss.location(), tp_id)
     except (KeyError, ValueError):
@@ -184,7 +184,8 @@ def procesar_entrega(msg):
         # Insertar, por el momento, la URL del repositorio.
         # TODO: insertar URL para un pull request si es el primer Todo OK.
         message = "Esta entrega fue importada a:"
-        output = TODO_OK_REGEX.sub(rf"\g<0>\n{message}\n{alu_repo.url}", output)
+        output = TODO_OK_REGEX.sub(
+            rf"\g<0>\n\n{message}\n{alu_repo.url}/tree/{tp_id}", output)
 
   firma = "URL de esta entrega (para uso docente):\n" + moss.url()
   send_reply(msg, f"{output}\n\n-- \n{firma}")

--- a/install.sh
+++ b/install.sh
@@ -16,9 +16,10 @@ source "conf/corrector.env"
 
 # Instalar software
 
-env DEBIAN_FRONTEND=noninteractive \
-apt-get install --assume-yes --no-install-recommends \
-    gcc libc6-dev fetchmail python3 python3-oauth2client ca-certificates
+env DEBIAN_FRONTEND=noninteractive            \
+apt-get install --yes --no-install-recommends \
+    gcc libc6-dev fetchmail ca-certificates   \
+    python3 python3-git python3-oauth2client
 
 ##
 

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ source "conf/corrector.env"
 env DEBIAN_FRONTEND=noninteractive            \
 apt-get install --yes --no-install-recommends \
     gcc libc6-dev fetchmail ca-certificates   \
-    python3 python3-git python3-oauth2client
+    python3 python3-git python3-oauth2client python3-github
 
 ##
 

--- a/pull_requests.py
+++ b/pull_requests.py
@@ -63,6 +63,7 @@ def parse_args():
         default=ENTREGAS_REPO,
         help="ruta a un checkout de algoritmos-rw/algo2_entregas",
     )
+    parser.add_argument("--pull-entregas", action="store_true")
     return parser.parse_args()
 
 
@@ -74,9 +75,6 @@ USERNAMES = {
     "105147": "juancebarberis",
     "105296": "nazaquintero",
 }
-
-
-# TODO: usar bare repos?
 
 
 def overwrite_files(repo, tree, subdir=""):
@@ -197,7 +195,6 @@ def update_repo(branch, subdir, upstream):
             committer=author,
             commit_date=authored_date,
         )
-        # XXX
         repo.index.reset(working_tree=True)
 
 
@@ -220,6 +217,11 @@ def main():
     except git.exc.InvalidGitRepositoryError as ex:
         print(f"could not open entregas_repo at {repodir!r}: {ex}", file=sys.stderr)
         return 1
+
+    if args.pull_entregas:
+        print(f"Pulling from {args.entregas_repo}")
+        remote = tprepo.remote()
+        remote.pull()
 
     for repo in args.repos:
         legajo = os.path.basename(repo)  # XXX: Drop this

--- a/pull_requests.py
+++ b/pull_requests.py
@@ -1,0 +1,183 @@
+#!/usr/bin/python3
+
+import io
+import os
+import sys
+
+import git
+import git.index.fun as indexfun
+import git.objects.fun as objfun
+
+from git.util import bin_to_hex, stream_copy
+from git.objects import Blob
+from git.index.typ import BaseIndexEntry
+from gitdb.base import IStream
+
+
+# TODO: do not hardcode these
+TP = "tp0"
+CUAT = "2020_1"
+
+# TODO: accept command line options
+TPREPO = os.path.expanduser("~/fiuba/tprepo")
+ALUREPO = os.path.expanduser("~/fiuba/alurepo")
+
+# TODO: DEFINITELY do not hardcode these
+USERNAMES = {
+    "103457": "tomascosta3",
+    "103740": "milognr",
+    "104302": "angysaavedra",
+    "105147": "juancebarberis",
+    "105296": "nazaquintero",
+}
+
+
+# TODO: usar bare repos?
+
+
+def overwrite_files(repo, tree, subdir=""):
+    """Sobreescribe archivos en un repositorio con contenidos de otro árbol.
+
+    Args:
+      repo (git.Repo): repo destino.
+      tree (git.Tree): árbol con los nuevos contenidos.
+      prefix (string): subdirectorio del repositorio donde realizar el remplazo.
+
+    Returns:
+      el nuevo árbol raíz (git.Tree) del repositorio destino.
+    """
+    objdb = tree.repo.odb
+    prefix = ""
+    old_tree = repo.tree()
+
+    if subdir:
+        path = subdir.rstrip("/")
+        prefix = f"{path}/"
+        old_tree = old_tree.join(path)
+
+    old_files = objfun.traverse_tree_recursive(repo.odb, old_tree.binsha, prefix)
+    new_files = objfun.traverse_tree_recursive(objdb, tree.binsha, prefix)
+
+    new_entries = merged_entries([], new_files)
+    all_entries = merged_entries(old_files, new_files)
+
+    # Copy new files into repository.
+    for entry in new_entries:
+        blob = io.BytesIO()
+        stream_copy(objdb.stream(entry.binsha), blob)
+        blob.seek(0)
+        size = len(blob.getvalue())
+        result = repo.odb.store(IStream(Blob.type, size, blob))
+        assert result[0] == entry.binsha
+
+    # Create tree with all entries (old and new) and return it.
+    tree_binsha, _ = indexfun.write_tree_from_cache(
+        all_entries, repo.odb, slice(0, len(all_entries))
+    )
+    return repo.tree(bin_to_hex(tree_binsha).decode("ascii"))
+
+
+def merged_entries(old_traversal, new_traversal):
+    ot = {e[2]: e for e in old_traversal}
+    nt = {e[2]: e for e in new_traversal}
+    merged_entries = []
+
+    ot.update(nt)
+
+    for _, (sha, mode, path) in sorted(ot.items()):
+        merged_entries.append(BaseIndexEntry((mode, sha, 0, path)))
+
+    return merged_entries
+
+
+def update_repo(legajo, repo):
+    """Actualiza el repositorio correspondiente a un legajo.
+
+    La función examina las entregas en el repositorio global de entregas,
+    y aplica las faltantes al repositorio destino.
+
+    Args:
+      legajo (string): el legado correspondiente al repositorio
+      repo (git.Repo): el repositorio destino
+    """
+    print(f"Processing {legajo}")
+    tprepo = git.Repo(TPREPO)
+    tppath = f"{TP}/{CUAT}/{legajo}"
+    branch = get_branch(repo, TP)
+    newest_in_repo = branch.commit.authored_date
+    pending_commits = []
+
+    for commit in tprepo.iter_commits(paths=[tppath]):
+        if commit.authored_date > newest_in_repo:  # XXX Not robust enough.
+            pending_commits.append(commit)
+
+    if not pending_commits:
+        print(f"Nothing to do for {legajo}/{TP}", file=sys.stderr)
+        # XXX
+        repo.index.reset(working_tree=True)
+        return
+    else:
+        n = len(pending_commits)
+        print(f"Applying {n} commits to {legajo}/{TP}", file=sys.stderr)
+
+    index = repo.index
+    try:
+        ghuser = USERNAMES[legajo]
+    except KeyError:
+        print(f"No username for {legajo}", file=sys.stderr)
+        return
+    else:
+        author = git.Actor(ghuser, f"{ghuser}@users.noreply.github.com")
+
+    branch.checkout()
+
+    for commit in reversed(pending_commits):
+        # Objeto Tree con los archivos de la entrega.
+        entrega_tree = commit.tree.join(tppath)
+        updated_tree = overwrite_files(repo, entrega_tree, TP)
+
+        tz_hours = commit.author_tz_offset // 3600
+        tz_minutes = commit.author_tz_offset % 3600 // 60
+        authored_date = f"{commit.authored_date} {tz_hours:+03}{tz_minutes:02}"
+
+        git.Commit.create_from_tree(
+            repo,
+            updated_tree,
+            commit.message,
+            head=True,
+            author=author,
+            author_date=authored_date,
+            committer=author,
+            commit_date=authored_date,
+        )
+
+        # XXX
+        repo.index.reset(working_tree=True)
+
+
+def get_branch(repo, branch_name):
+    """Dado un repo, devolver la rama con ese nombre.
+    """
+    for branch in repo.branches:
+        if branch.name == branch_name:
+            return branch
+
+
+def main():
+    for repodir in os.listdir(ALUREPO):
+        path = os.path.join(ALUREPO, repodir)
+        try:
+            repo = git.Repo(path)
+        except git.exc.InvalidGitRepositoryError as ex:
+            print(f"could not open {repodir!r}: {ex}", file=sys.stderr)
+        else:
+            # TODO: opportunistically return pull request URL.
+            update_repo(repodir, repo)
+
+
+if __name__ == "__main__":
+    main()
+
+# Local Variables:
+# eval: (blacken-mode 1)
+# End:

--- a/pull_requests.py
+++ b/pull_requests.py
@@ -96,7 +96,7 @@ def main():
         if not upstream.exists():
             continue
         try:
-            alu_repo = AluRepo.from_legajo(legajo)
+            alu_repo = AluRepo.from_legajos([legajo], args.tp)
             alu_repo.ensure_exists(skel_repo="algorw-alu/algo2_tps")
             alu_repo.sync(upstream, args.tp)
         except (KeyError, ValueError, github.GithubException) as ex:

--- a/pull_requests.py
+++ b/pull_requests.py
@@ -45,7 +45,7 @@ PULLREQ_URL = "https://github.com/{repo}/compare/master...{branch}?quick_pull=1"
 
 ## Función principal para corrector.py
 ##
-def update_repo(tp_id, repodir, upstream, planilla_tsv, silent=True):
+def update_repo(tp_id, repodir, upstream, planilla_tsv, fetch=True, silent=True):
     """Importa la última versión de una entrega a un repositorio individual.
 
     Args:
@@ -91,7 +91,8 @@ def update_repo(tp_id, repodir, upstream, planilla_tsv, silent=True):
     try:
         repo = git.Repo(repodir)
         origin = repo.remotes["origin"]
-        origin.fetch()
+        if fetch:
+            origin.fetch()
     except (git.exc.InvalidGitRepositoryError, git.exc.GitCommandError) as ex:
         print(f"could not open/fetch {repodir!r}: {ex}", file=sys.stderr)
         return
@@ -167,6 +168,7 @@ def parse_args():
         help="ruta a un checkout de algoritmos-rw/algo2_entregas",
     )
     parser.add_argument("--pull-entregas", action="store_true")
+    parser.add_argument("--no-fetch", dest="fetch", default=True, action="store_false")
     return parser.parse_args()
 
 
@@ -249,7 +251,7 @@ def update_branch(branch, subdir, upstream, ghuser):
     upstream_repo = git.Repo(upstream, search_parent_directories=True)
     upstream_relpath = upstream.relative_to(upstream_repo.working_dir).as_posix()
 
-    print(f"Processing {repo.working_dir}...", end=" ")
+    print(f"Processing {repo.working_dir} ...", end=" ")
 
     for commit in upstream_repo.iter_commits(paths=[upstream_relpath]):
         if commit.authored_date > newest_in_repo:  # XXX Not robust enough.

--- a/pull_requests.py
+++ b/pull_requests.py
@@ -59,6 +59,11 @@ def update_repo(tp_id, repodir, upstream, planilla_tsv, silent=True):
     """
     legajo = repodir.name  # Siempre cumplimos que `basename $REPO` == legajo.
     alu_dict = None
+    try:
+        upstream = upstream.resolve(strict=True)
+    except FileNotFoundError as ex:
+        print(f"no such upstream: {upstream}")
+        return
 
     # Buscar legajo en la "planilla".
     with open(planilla_tsv, newline="") as fileobj:
@@ -339,13 +344,7 @@ def main():
     for legajo in args.legajos:
         alurepo = repodir / legajo
         upstream = entregas_repo / args.tp / args.cuatri / legajo
-        if upstream.exists():
-            update_repo(args.tp, alurepo, upstream, args.planilla)
-        else:
-            print(
-                f"no hay entrega para {upstream.relative_to(entregas_repo)}",
-                file=sys.stderr,
-            )
+        update_repo(args.tp, alurepo, upstream, args.planilla, fetch=args.fetch)
 
 
 if __name__ == "__main__":

--- a/pull_requests.py
+++ b/pull_requests.py
@@ -85,12 +85,40 @@ def update_repo(tp_id, repodir, upstream, planilla_tsv, silent=True):
 
     try:
         repo = git.Repo(repodir)
-    except git.exc.InvalidGitRepositoryError as ex:
-        print(f"could not open {repodir!r}: {ex}", file=sys.stderr)
+        origin = repo.remotes["origin"]
+        origin.fetch()
+    except (git.exc.InvalidGitRepositoryError, git.exc.GitCommandError) as ex:
+        print(f"could not open/fetch {repodir!r}: {ex}", file=sys.stderr)
+        return
+
+    branch = get_or_checkout_branch(repo, tp_id, fast_forward=True)
+    pullreq_url = None
+    initial_commit = branch.commit
+
+    if not update_branch(branch, tp_id, upstream, alu_dict["Github"]):
+        return None
+
+    # Return a pull request URL if initial commit was merged in master.
+    if is_merged(initial_commit, "origin/master"):
+        repo_id = alu_dict["Repo"]  # XXX Technically could fail, see our sanity checks.
+        pullreq_url = PULLREQ_URL.format(repo=repo_id, branch=branch.name)
+        # TODO: Put this hack somewhere else.
+        apellido = repo_id.split("_")[-1].capitalize()
+        pullreq_url += f"&title=%5balgo2%5d%20{tp_id}%20%E2%80%93%20{apellido}"
+
+    try:
+        origin.push(branch.name)
+    except git.exc.GitCommandError as ex:
+        print(f"could not push {repodir!r}: {ex}", file=sys.stderr)
     else:
-        # TODO: opportunistically return pull request URL.
-        branch = get_or_checkout_branch(repo, tp_id)
-        update_branch(branch, tp_id, upstream, alu_dict["Github"])
+        return pullreq_url
+
+
+def is_merged(commit, branch_name):
+    branches = commit.repo.git.branch(
+        ["-a", "--format=%(refname:short)", "--contains", commit.hexsha]
+    )
+    return branch_name in branches.splitlines()
 
 
 def parse_args():
@@ -205,6 +233,9 @@ def update_branch(branch, subdir, upstream, ghuser):
       subdir (str): el subdirectorio particular a sincronizar con upstream
       upstream (Path): ruta en repo externo con los archivos actualizados
       ghuser (str): nombre de cuenta de Github con que crear los commits.
+
+    Returns:
+      True si se actualizó la rama, False si no se agregaron commits.
     """
     repo = branch.repo
     newest_in_repo = branch.commit.authored_date
@@ -221,7 +252,7 @@ def update_branch(branch, subdir, upstream, ghuser):
 
     if not pending_commits:
         print(f"nothing to do")
-        return
+        return False
 
     print(f"applying {len(pending_commits)} commit(s)")
 
@@ -248,6 +279,8 @@ def update_branch(branch, subdir, upstream, ghuser):
             commit_date=authored_date,
         )
         repo.index.reset(working_tree=True)
+
+    return True
 
 
 def get_or_checkout_branch(repo, branch_name, fast_forward=False):

--- a/pull_requests.py
+++ b/pull_requests.py
@@ -81,12 +81,15 @@ def update_repo(tp_id, repodir, upstream, planilla_tsv, fetch=True, silent=True)
     if not alu_dict.get("Github"):
         print(f"no se pudo encontrar cuenta de Github para {legajo}")
         return
-    elif not repodir.exists() and not alu_dict.get("Repo"):
+    elif not (repo := alu_dict.get("Repo")):
         print(f"no se pudo encontrar repo URL para {legajo}")
         return
-
-    if not repodir.exists():
-        git.Repo.clone_from("git@github.com:" + alu_dict["Repo"], repodir)
+    elif not repodir.exists():
+        try:
+            git.Repo.clone_from(f"git@github.com:{repo}", repodir)
+        except git.exc.GitCommandError as ex:
+            print(f"no se pudo clonar {repo}: {ex}")
+            return
 
     try:
         repo = git.Repo(repodir)

--- a/pull_requests.py
+++ b/pull_requests.py
@@ -1,133 +1,38 @@
 #!/usr/bin/python3
 
-"""Script/módulo para sincronizar las entregas con repositorios individuales.
+"""Script para sincronizar las entregas con repositorios individuales.
 
 Uso como script:
 
   $ ./pull_requests.py --tp <TP_ID> <legajo>...
 
-donde TP_ID es el TP a sincronizar ("tp0", "vector", etc.). Se puede
-especificar la ubicación del checkout de algoritmos-rw/algo2_entregas
-con la opción --entregas-repo, y la ubicación de los repositorios
-individuales con --alu-repodir. fiubatp.tsv debe estar presente en el
-directorio actual, o especificarse con --planilla.
-
-Uso como módulo: llamar a update_repo() indicando el TP, la ruta a la
-entrega, y el directorio con los repositorios individuales.
+donde TP_ID es el TP a sincronizar ("tp0", "vector", etc.). La ubicación
+del repositorio algoritmos-rw/algo2_entregas se puede especificar con la
+opción --entregas-repo. repos.tsv debe estar presente en el directorio
+actual, o especificarse con --planilla.
 """
 
 import argparse
-import csv
-import io
 import os
 import pathlib
 import sys
 
-import git  # apt install python3-git
-import git.index.fun as indexfun
-import git.objects.fun as objfun
+import git
+import github
 
-from git.util import bin_to_hex, stream_copy
-from git.objects import Blob
-from git.index.typ import BaseIndexEntry
-from gitdb.base import IStream
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    pass
+else:
+    load_dotenv()  # Debe hacerse antes del import de AluRepo.
+
+from alu_repos import AluRepo
 
 
 # Defaults si no se ajustan por la línea de comandos.
 ENTREGAS_REPO = os.path.expanduser("~/fiuba/tprepo")
-ALU_REPOS_DIR = os.path.expanduser("~/fiuba/alurepo")
-
-# Default si no se especifica con --cuatri.
 CUATRIMESTRE = "2020_1"
-
-# URLs para creación de pull request.
-PULLREQ_URL = "https://github.com/{repo}/compare/master...{branch}?quick_pull=1"
-
-## Función principal para corrector.py
-##
-def update_repo(tp_id, repodir, upstream, planilla_tsv, fetch=True, silent=True):
-    """Importa la última versión de una entrega a un repositorio individual.
-
-    Args:
-      tp_id (str): identificador del TP (dobla como subdirectorio y rama)
-      repodir (Path): ruta al repositorio destino (se clona si no existe)
-      upstream (Path): ruta en repo externo con los archivos actualizados
-      planilla_file (str): hoja "fiubatp" de la planilla exportada en TSV
-
-    Returns:
-      URL para crear pull request si la rama estaba previamente integrada.
-    """
-    legajo = repodir.name  # Siempre cumplimos que `basename $REPO` == legajo.
-    alu_dict = None
-    try:
-        upstream = upstream.resolve(strict=True)
-    except FileNotFoundError as ex:
-        print(f"no such upstream: {upstream}")
-        return
-
-    # Buscar legajo en la "planilla".
-    with open(planilla_tsv, newline="") as fileobj:
-        for row in csv.DictReader(fileobj, dialect="excel-tab"):
-            if row["Legajo"] == legajo:
-                alu_dict = row
-                break
-        else:
-            if not silent:
-                # Demasiado spam si la planilla solo tiene los legajos habilitados.
-                print(f"no se pudo encontrar legajo {legajo} en {planilla_tsv}")
-            return
-
-    # Sanity checks.
-    if not alu_dict.get("Github"):
-        print(f"no se pudo encontrar cuenta de Github para {legajo}")
-        return
-    elif not (repo := alu_dict.get("Repo")):
-        print(f"no se pudo encontrar repo URL para {legajo}")
-        return
-    elif not repodir.exists():
-        try:
-            git.Repo.clone_from(f"git@github.com:{repo}", repodir)
-        except git.exc.GitCommandError as ex:
-            print(f"no se pudo clonar {repo}: {ex}")
-            return
-
-    try:
-        repo = git.Repo(repodir)
-        origin = repo.remotes["origin"]
-        if fetch:
-            origin.fetch()
-    except (git.exc.InvalidGitRepositoryError, git.exc.GitCommandError) as ex:
-        print(f"could not open/fetch {repodir!r}: {ex}", file=sys.stderr)
-        return
-
-    branch = get_or_checkout_branch(repo, tp_id, fast_forward=True)
-    pullreq_url = None
-    initial_commit = branch.commit
-
-    if not update_branch(branch, tp_id, upstream, alu_dict["Github"]):
-        return None
-
-    # Return a pull request URL if initial commit was merged in master.
-    if is_merged(initial_commit, "origin/master"):
-        repo_id = alu_dict["Repo"]  # XXX Technically could fail, see our sanity checks.
-        pullreq_url = PULLREQ_URL.format(repo=repo_id, branch=branch.name)
-        # TODO: Put this hack somewhere else.
-        apellido = repo_id.split("_")[-1].capitalize()
-        pullreq_url += f"&title=%5balgo2%5d%20{tp_id}%20%E2%80%93%20{apellido}"
-
-    try:
-        origin.push(branch.name)
-    except git.exc.GitCommandError as ex:
-        print(f"could not push {repodir!r}: {ex}", file=sys.stderr)
-    else:
-        return pullreq_url
-
-
-def is_merged(commit, branch_name):
-    branches = commit.repo.git.branch(
-        ["-a", "--format=%(refname:short)", "--contains", commit.hexsha]
-    )
-    return branch_name in branches.splitlines()
 
 
 def parse_args():
@@ -155,14 +60,8 @@ def parse_args():
     parser.add_argument(
         "--planilla",
         metavar="TSV_FILE",
-        default="fiubatp.tsv",
+        default="repos.tsv",
         help="archivo TSV con los contenidos de la hoja 'fiubatp'",
-    )
-    parser.add_argument(
-        "--alu-repodir",
-        metavar="PATH",
-        default=ALU_REPOS_DIR,
-        help="directorio con los repositorios individuales",
     )
     parser.add_argument(
         "--entregas-repo",
@@ -171,174 +70,20 @@ def parse_args():
         help="ruta a un checkout de algoritmos-rw/algo2_entregas",
     )
     parser.add_argument("--pull-entregas", action="store_true")
-    parser.add_argument("--no-fetch", dest="fetch", default=True, action="store_false")
+    parser.add_argument("--debug", action="store_true", default=True)
     return parser.parse_args()
-
-
-def overwrite_files(repo, tree, subdir=""):
-    """Sobreescribe archivos en un repositorio con contenidos de otro árbol.
-
-    Args:
-      repo (git.Repo): repo destino.
-      tree (git.Tree): árbol con los nuevos contenidos.
-      prefix (string): subdirectorio del repositorio donde realizar el remplazo.
-
-    Returns:
-      el nuevo árbol raíz (git.Tree) del repositorio destino.
-    """
-    objdb = tree.repo.odb
-    prefix = ""
-    old_tree = repo.tree()
-
-    if subdir:
-        path = subdir.rstrip("/")
-        prefix = f"{path}/"
-        old_tree = old_tree.join(path)
-
-    old_files = objfun.traverse_tree_recursive(repo.odb, old_tree.binsha, prefix)
-    new_files = objfun.traverse_tree_recursive(objdb, tree.binsha, prefix)
-
-    new_entries = merged_entries([], new_files)
-    all_entries = merged_entries(old_files, new_files)
-
-    # Copy new files into repository.
-    for entry in new_entries:
-        blob = io.BytesIO()
-        stream_copy(objdb.stream(entry.binsha), blob)
-        blob.seek(0)
-        size = len(blob.getvalue())
-        result = repo.odb.store(IStream(Blob.type, size, blob))
-        assert result[0] == entry.binsha
-
-    # Create tree with all entries (old and new) and return it.
-    tree_binsha, _ = indexfun.write_tree_from_cache(
-        all_entries, repo.odb, slice(0, len(all_entries))
-    )
-    return repo.tree(bin_to_hex(tree_binsha).decode("ascii"))
-
-
-def merged_entries(old_traversal, new_traversal):
-    ot = {e[2]: e for e in old_traversal}
-    nt = {e[2]: e for e in new_traversal}
-    merged_entries = []
-
-    ot.update(nt)
-
-    for _, (sha, mode, path) in sorted(ot.items()):
-        merged_entries.append(BaseIndexEntry((mode, sha, 0, path)))
-
-    return merged_entries
-
-
-def update_branch(branch, subdir, upstream, ghuser):
-    """Actualiza una rama con archivos de otro repo.
-
-    La función examina los commits en el upstream, y aplica los faltantes
-    en la rama destino.
-
-    TODO: Explicar (y mejorar) cómo se detecta qué falta.
-
-    Args:
-      branch (git.Branch): la rama donde aplicar las actualizaciones
-      subdir (str): el subdirectorio particular a sincronizar con upstream
-      upstream (Path): ruta en repo externo con los archivos actualizados
-      ghuser (str): nombre de cuenta de Github con que crear los commits.
-
-    Returns:
-      True si se actualizó la rama, False si no se agregaron commits.
-    """
-    repo = branch.repo
-    newest_in_repo = branch.commit.authored_date
-    pending_commits = []
-
-    upstream_repo = git.Repo(upstream, search_parent_directories=True)
-    upstream_relpath = upstream.relative_to(upstream_repo.working_dir).as_posix()
-
-    print(f"Processing {repo.working_dir} ...", end=" ")
-
-    for commit in upstream_repo.iter_commits(paths=[upstream_relpath]):
-        if commit.authored_date > newest_in_repo:  # XXX Not robust enough.
-            pending_commits.append(commit)
-
-    if not pending_commits:
-        print(f"nothing to do")
-        return False
-
-    print(f"applying {len(pending_commits)} commit(s)")
-
-    branch.checkout()
-    author = git.Actor(ghuser, f"{ghuser}@users.noreply.github.com")
-
-    for commit in reversed(pending_commits):
-        # Objeto Tree con los archivos de la entrega.
-        entrega_tree = commit.tree.join(upstream_relpath)
-        updated_tree = overwrite_files(repo, entrega_tree, subdir)
-
-        tz_hours = commit.author_tz_offset // 3600
-        tz_minutes = commit.author_tz_offset % 3600 // 60
-        authored_date = f"{commit.authored_date} {tz_hours:+03}{tz_minutes:02}"
-
-        git.Commit.create_from_tree(
-            repo,
-            updated_tree,
-            commit.message,
-            head=True,
-            author=author,
-            author_date=authored_date,
-            committer=author,
-            commit_date=authored_date,
-        )
-        repo.index.reset(working_tree=True)
-
-    return True
-
-
-def get_or_checkout_branch(repo, branch_name, fast_forward=False):
-    """Dado un repo, devolver la rama con ese nombre.
-
-    Si la rama no existe, se crea a partir de una rama remota llamada igual
-    o de la rama master local.
-
-    Args:
-      fast_forward (bool): si verdadero, hacer fast-forward desde la rama upstream.
-    """
-    upstream = f"origin/{branch_name}"
-    try:
-        branch = repo.branches[branch_name]
-    except IndexError:
-        # Hacer checkout desde remote o master.
-        for args in ["-t", upstream], ["-b", branch_name, "master"]:
-            try:
-                repo.git.checkout(args)
-            except git.exc.GitCommandError:
-                pass
-            else:
-                return repo.branches[branch_name]
-
-    if fast_forward:
-        branch.checkout()
-        tracking = branch.tracking_branch()
-        if tracking:
-            upstream = tracking.name
-        try:
-            repo.git.merge(["--ff-only", upstream])
-        except git.exc.GitCommandError:
-            pass
-
-    return branch
 
 
 def main():
     """Función principal del script (no invocada si se importa como módulo).
     """
     args = parse_args()
-    repodir = pathlib.Path(args.alu_repodir)
     entregas_repo = pathlib.Path(args.entregas_repo)
 
     try:
         tprepo = git.Repo(args.entregas_repo)
     except git.exc.InvalidGitRepositoryError as ex:
-        print(f"could not open entregas_repo at {repodir!r}: {ex}", file=sys.stderr)
+        print(f"could not open entregas_repo: {ex}", file=sys.stderr)
         return 1
 
     if args.pull_entregas:
@@ -347,9 +92,17 @@ def main():
         remote.pull()
 
     for legajo in args.legajos:
-        alurepo = repodir / legajo
         upstream = entregas_repo / args.tp / args.cuatri / legajo
-        update_repo(args.tp, alurepo, upstream, args.planilla, fetch=args.fetch)
+        if not upstream.exists():
+            continue
+        try:
+            alu_repo = AluRepo.from_legajo(legajo)
+            alu_repo.ensure_exists(skel_repo="algorw-alu/algo2_tps")
+            alu_repo.sync(upstream, args.tp)
+        except (KeyError, ValueError, github.GithubException) as ex:
+            print(f"error al procesar {legajo}: {ex}")
+            if args.debug:
+                raise ex from ex
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+include = '''
+/(
+| pull_requests.py
+)$
+'''
+target-version = ['py36']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [tool.black]
 include = '''
 /(
-| pull_requests.py
+| sync_repo
+| alu_repos.py
 )$
 '''
 target-version = ['py36']

--- a/sync_repo
+++ b/sync_repo
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
 
-"""Script para sincronizar las entregas con repositorios individuales.
+"""Script para sincronizar manualmente los repositorios individuales.
 
-Uso como script:
+Uso:
 
-  $ ./pull_requests.py --tp <TP_ID> <legajo>...
+  $ ./sync_repo --tp <TP_ID> <legajo>...
 
 donde TP_ID es el TP a sincronizar ("tp0", "vector", etc.). La ubicación
 del repositorio algoritmos-rw/algo2_entregas se puede especificar con la
@@ -61,7 +61,7 @@ def parse_args():
         "--planilla",
         metavar="TSV_FILE",
         default="repos.tsv",
-        help="archivo TSV con los contenidos de la hoja 'fiubatp'",
+        help="archivo TSV con los contenidos de la hoja 'Repos'",
     )
     parser.add_argument(
         "--entregas-repo",
@@ -107,6 +107,7 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+
 
 # Local Variables:
 # eval: (blacken-mode 1)


### PR DESCRIPTION
Con el objetivo de poder realizar correcciones por pull requests,
pero sin que les alumnes tengan que preocuparse de usar Git y
hacer push, se añade un módulo capaz de hacer forward de las
entregas a repositorios individuales, y de sugerir URLs para la
creación de pull requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/corrector/42)
<!-- Reviewable:end -->
