### PR TITLE
Upgrade a focal de la imagen Docker del worker.

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,15 +1,12 @@
 # -*- docker-image-name: "algoritmosrw/corrector" -*-
 
-FROM ubuntu:bionic
+FROM ubuntu:focal-20200423
 
-RUN apt-get update     && \
-    apt-get upgrade -y && \
-    apt-get install -y gcc gcc-multilib g++ clang      \
-                       make valgrind time python3 perl \
-                       openjdk-11-jdk-headless         \
-                       libgtest-dev python3-jinja2 &&  \
-    make -f /usr/src/googletest/googletest/make/Makefile -C /usr/local/lib \
-        gtest.a && ln -s gtest.a /usr/local/lib/libgtest.a
+RUN apt-get update && \
+    apt-get install --assume-yes --no-install-recommends       \
+        gcc g++ gcc-multilib make valgrind clang clang-format  \
+        perl python3 openjdk-11-jdk-headless libgtest-dev time \
+        python3-jinja2 python3-yaml wspanish
 
 COPY ["*.py", "*.j2", "/"]
 

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 
 """Worker para el corrector automático.
 


### PR DESCRIPTION
Otros cambios:

  - focal ya include googletest > 1.8.0-7, que trae las bibliotecas
    precompiladas; no hace falta compilarlas junto con la imagen.

  - usar una etiqueta de focal con fecha, y evitar apt-get upgrade
    (debería producir imágenes con versiones predecibles).

  - instalar wspanish para tener una fuente default de texto plano.

  - instalar python3-yaml, necesario para algoritmos-rw/algo2_skel#161.

  - instalar con --no-install-recommends.

  - cambiar el hashbang de worker.py de "python3.6" a "python3" a secas,
    pues focal ya trae solo 3.8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/corrector/49)
<!-- Reviewable:end -->
