### PR TITLE
Deshabilitar IMAP IDLE por default.

### DIFF
--- a/conf/corrector@.service
+++ b/conf/corrector@.service
@@ -4,6 +4,7 @@ After=docker.service
 
 [Service]
 User=%i
+Environment=LANG=C.UTF-8
 Environment=CORRECTOR_ROOT=/home/%i/corrector
 EnvironmentFile=/home/%i/corrector/conf/corrector.env
 ExecStart=/usr/bin/fetchmail --daemon 180 --nodetach \

--- a/conf/fetchmailrc
+++ b/conf/fetchmailrc
@@ -23,8 +23,12 @@ poll imap.gmail.com
   folder "entregas"
   no keep  # Borrar en Gmail equivale a quitar la etiqueta.
 
-  # IMAP IDLE deja la conexión abierta para detectar correo nuevo con rapidez.
-  idle
+  # IMAP IDLE deja la conexión abierta e inmediatamente detecta
+  # correo nuevo; excepto que últimamente no funciona demasiado
+  # bien: https://github.com/algoritmos-rw/corrector/issues/51.
+  # Sin idle, fetchmail comprueba el correo según el intervalo
+  # configurado con la opción --daemon en corrector@.service.
+  # idle
 
   # Por omisión fetchmail envía el correo recibido al puerto 25 de localhost.
   # Con localhost/discard evitamos que fetchmail corra por accidente sin la


### PR DESCRIPTION
Últimamente hemos visto IDLE tardar hasta 20 minutos en darse
cuenta de que hay correo nuevo. Es mejor comprobar cada 3 minutos,
y eventualmente coordinar con el sistema de entregas mediante una
cola de mensajes compartida.

Closes: #51.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/corrector/52)
<!-- Reviewable:end -->
