### PR TITLE
Entrar corrector.py en modo legacy, dejando de enviar mail

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -379,11 +379,9 @@ def send_reply(orig_msg, reply_text):
   reply = email.message.Message(email.policy.default)
   reply.set_payload(reply_text, "utf-8")
 
-  reply["From"] = GMAIL_ACCOUNT
-  reply["To"] = orig_msg["To"]
-  reply["Cc"] = orig_msg.get("Cc", "")
+  reply["From"] = "Corrector legacy <{}>".format(GMAIL_ACCOUNT)
+  reply["To"] = GMAIL_ACCOUNT
   reply["Subject"] = "Re: " + orig_msg["Subject"]
-  reply["Reply-To"] = orig_msg.get("Reply-To", "")
   reply["In-Reply-To"] = orig_msg["Message-ID"]
 
   creds = get_oauth_credentials()


### PR DESCRIPTION
A partir de ahora se promociona a principal a la instancia de corrector
de entregas, y queda esta instancia como legacy. Se lo sigue corriendo,
pero el mail de respuesta no se envía a les alumnes, solo a la casilla
de mails.

Las correcciones se siguen realizando, y las entregas guardando en el
repo, por redundancy hasta que se compruebe que el otro funciona bien.
No obstante, empezará a haber divergencias en comportamiento (por ejemplo,
rutas en el repo, ver algoritmos-rw/algo2_sistema_entregas#46).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/corrector/55)
<!-- Reviewable:end -->
