### PR TITLE
Desactivar la sincronización de alu_repos en el corrector legacy

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -169,7 +169,9 @@ def procesar_entrega(msg):
   if retcode != 0:
     raise ErrorInterno(output)
 
-  if TODO_OK_REGEX.search(output):
+  # Este código corre ahora desde el corrector.py del sistema de entregas.
+  # No lo borramos por si acaso hubiera que hacer un revert de emergencia.
+  if TODO_OK_REGEX.search(output) and False:
     try:
       # Sincronizar la entrega con los repositorios individuales.
       alu_repo = AluRepo.from_legajos(padron.split("_"), tp_id)


### PR DESCRIPTION
La idea es activar el mismo código en el corrector.py del sistema de
entregas (que ahora mismo se encuentra desactivado), pero sin necesidad
de TSV, y con mayor precisión sobre a cuál repo sincronizar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/corrector/57)
<!-- Reviewable:end -->
