### PR TITLE
Usar como imagen base para Docker la que se construye en la rama v3

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,12 +1,6 @@
 # -*- docker-image-name: "algoritmosrw/corrector" -*-
 
-FROM ubuntu:focal-20200423
-
-RUN apt-get update && \
-    apt-get install --assume-yes --no-install-recommends       \
-        gcc g++ gcc-multilib make valgrind clang clang-format  \
-        perl python3 openjdk-11-jdk-headless libgtest-dev time \
-        python3-jinja2 python3-yaml wspanish
+FROM algoritmosrw/corrector:v3
 
 COPY ["*.py", "*.j2", "/"]
 


### PR DESCRIPTION
La rama ‘v3’ de este repo contiene la definición de una imagen con los
mismos paquetes que la actual, pero más legiblemente definidos en un
archivo de texto aparte:

  https://github.com/algoritmos-rw/corrector/blob/5fcab0cef1a3/packages.txt

y con una Github Action que reconstruye y publica a Docker la imagen cada
vez que se cambia el listado de paquetes.

El procedimiento para construir la imagen en turing no cambia:

  $ cd worker
  $ sudo docker build -t algoritmosrw/corrector .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/corrector/58)
<!-- Reviewable:end -->
